### PR TITLE
PHP is all about being social and open-source

### DIFF
--- a/groups.md
+++ b/groups.md
@@ -1,10 +1,9 @@
-# Groups & Projects
+# Groups
 
-List of **non-commercial** groups and projects with the goal to talk PHP or write PHP (open-source projects, start-up ideas, hackatons). When adding a group, sort them by name and use this format:
+List of **php-related** groups that are in close proximity to London.  When adding a group use this format:
 
 ``` markdown
-### Group or project Name 
-Founder(s): 
+### Group Name  
 Purpose: Teach kids PHP
 We meet: Monthly hackaton in <address>
 
@@ -16,7 +15,7 @@ PHP Tech: e.g. WordPress, Laravel, etc.
 
 Some Markdown formatting for naming links is fine.
 
-A collection of companies organized alphabetically. Names that begin with a number e.g. 99 Designs, should be organized under **Numbers**.
+A collection of groups organized alphabetically. Names that begin with a number e.g. 99 Designs, should be organized under **Numbers**. Names starting with "PHP" should use the next word for classification, e.g. "PHP London" should be under "L".
 
 
 ## Numbers
@@ -24,28 +23,17 @@ A collection of companies organized alphabetically. Names that begin with a numb
 
 ## A
 
-### Agile Data (MIT)
-
-Purpose: Data Access Framework for high-latency databases.
-We meet: Monthly in Parcel Yard, Kings Cross Station.
-
-* https://github.com/atk4/data/
-* @atk4, Chat: https://gitter.im/atk4/atk4
-
-PHP Tech: Composer (usable in all major apps/frameworks)
-
-### Agile UI (MIT)
-
-Purpose: Generic Web UI framework based on standard CSS framework.
-We meet: no schedule
-
-* https://github.com/atk4/ui
-
-PHP Tech: Composer (usable in all major apps/frameworks)
-
 ## B
 
 ## C
+
+### PHP Cambridge
+
+Purpose: 5-10 PHP-dev meetup, Great for general group discussions.
+We meet: Monthly in Cambridge
+
+* https://www.meetup.com/phpcambridge/
+* @twitter, chat:// - ?
 
 ## D
 
@@ -64,6 +52,14 @@ PHP Tech: Composer (usable in all major apps/frameworks)
 ## K
 
 ## L
+
+###  PHP London
+
+Purpose: General PHP Meetup, great presentations
+We meet: Monthly
+
+* https://www.meetup.com/phplondon/
+* Slack: https://phplondonslack.herokuapp.com
 
 ## M
 

--- a/groups.md
+++ b/groups.md
@@ -39,7 +39,7 @@ PHP Tech: Composer (usable in all major apps/frameworks)
 Purpose: Generic Web UI framework based on standard CSS framework.
 We meet: no schedule
 
-* http://github.com/atk4/ui
+* https://github.com/atk4/ui
 
 PHP Tech: Composer (usable in all major apps/frameworks)
 

--- a/groups.md
+++ b/groups.md
@@ -29,7 +29,7 @@ A collection of companies organized alphabetically. Names that begin with a numb
 Purpose: Data Access Framework for high-latency databases.
 We meet: Monthly in Parcel Yard, Kings Cross Station.
 
-* https://git.io/ad
+* https://github.com/atk4/data/
 * @atk4, Chat: https://gitter.im/atk4/atk4
 
 PHP Tech: Composer (usable in all major apps/frameworks)

--- a/groups.md
+++ b/groups.md
@@ -26,23 +26,20 @@ A collection of companies organized alphabetically. Names that begin with a numb
 
 ### Agile Data (MIT)
 
-Founder: http://nearly.guru/
 Purpose: Data Access Framework for high-latency databases.
 We meet: Monthly in Parcel Yard, Kings Cross Station.
 
 * http://git.io/ad
-* Chat: http://gitter.im/atk4/atk4
+* @atk4, Chat: https://gitter.im/atk4/atk4
 
 PHP Tech: Composer (usable in all major apps/frameworks)
 
 ### Agile UI (MIT)
 
-Founder: http://nearly.guru/
 Purpose: Generic Web UI framework based on standard CSS framework.
 We meet: no schedule
 
 * http://github.com/atk4/ui
-* Chat: http://gitter.im/atk4/atk4
 
 PHP Tech: Composer (usable in all major apps/frameworks)
 

--- a/groups.md
+++ b/groups.md
@@ -1,0 +1,108 @@
+# Groups & Projects
+
+List of **non-commercial** groups and projects with the goal to talk PHP or write PHP (open-source projects, start-up ideas, hackatons). When adding a group, sort them by name and use this format:
+
+``` markdown
+### Group or project Name 
+Founder(s): 
+Purpose: Teach kids PHP
+We meet: Monthly hackaton in <address>
+
+* https://example.com
+* @twitter, chat://
+
+PHP Tech: e.g. WordPress, Laravel, etc.
+```
+
+Some Markdown formatting for naming links is fine.
+
+A collection of companies organized alphabetically. Names that begin with a number e.g. 99 Designs, should be organized under **Numbers**.
+
+
+## Numbers
+
+
+## A
+
+### Agile Data (MIT)
+
+Founder: http://nearly.guru/
+Purpose: Data Access Framework for high-latency databases.
+We meet: Monthly in Parcel Yard, Kings Cross Station.
+
+* http://git.io/ad
+* Chat: http://gitter.im/atk4/atk4
+
+PHP Tech: Composer (usable in all major apps/frameworks)
+
+### Agile UI (MIT)
+
+Founder: http://nearly.guru/
+Purpose: Generic Web UI framework based on standard CSS framework.
+We meet: no schedule
+
+* http://github.com/atk4/ui
+* Chat: http://gitter.im/atk4/atk4
+
+PHP Tech: Composer (usable in all major apps/frameworks)
+
+## B
+
+## C
+
+## D
+
+## E
+
+## F
+
+## G
+
+## H
+
+## I
+
+## J
+
+## K
+
+## L
+
+## M
+
+## N
+
+## O
+
+## P
+
+
+## Q
+
+
+## R
+
+
+## S
+
+
+## T
+
+## U
+
+
+## V
+
+
+## W
+
+## X
+
+
+## Y
+
+
+## Z
+
+----
+Want to add your group / community? Something is wrong in this list? Just <a href="https://github.com/alister/php-in-london/edit/master/companies.md">fork and edit</a> it!  Edits can be done in just a moment entirely within the Github website.

--- a/groups.md
+++ b/groups.md
@@ -29,7 +29,7 @@ A collection of companies organized alphabetically. Names that begin with a numb
 Purpose: Data Access Framework for high-latency databases.
 We meet: Monthly in Parcel Yard, Kings Cross Station.
 
-* http://git.io/ad
+* https://git.io/ad
 * @atk4, Chat: https://gitter.im/atk4/atk4
 
 PHP Tech: Composer (usable in all major apps/frameworks)

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,97 @@
+# Open-Source Projects
+
+List of **open-source** projects with authors or major contributors living in close proximity to London. Participating in open-source project is great opportunity to learn and to help community. Seek out author/contributor at the next PHP London event for a chat:
+
+``` markdown
+### Project Name 
+
+https://example.com
+Description
+
+- Name Surname (role)
+  Best event to meet
+
+- Name Surname (role)
+  Best event to meet
+
+```
+
+Some Markdown formatting for naming links is fine.
+
+A collection of projects are  organized alphabetically. Names that begin with a number e.g. 99 Designs, should be organized under **Numbers**.
+
+
+## Numbers
+
+
+## A
+
+### Agile Data (MIT)
+
+https://github.com/atk4/data/
+
+Data Access Framework for high-latency databases.
+
+-   Romans Malinovskis (lead developer)
+    Meet me at PHP London or PHP Cambridge.
+
+## B
+
+## C
+
+## D
+
+## E
+
+## F
+
+## G
+
+## H
+
+## I
+
+## J
+
+## K
+
+## L
+
+## M
+
+## N
+
+## O
+
+## P
+
+
+## Q
+
+
+## R
+
+
+## S
+
+
+## T
+
+## U
+
+
+## V
+
+
+## W
+
+## X
+
+
+## Y
+
+
+## Z
+
+----
+Want to add your group / community? Something is wrong in this list? Just <a href="https://github.com/alister/php-in-london/edit/master/companies.md">fork and edit</a> it!  Edits can be done in just a moment entirely within the Github website.

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ edit directly from within the Github website if you want).
 * [Companies](companies.md)
 * [Recruiters](recruiters.md)
 * [Groups](groups.md)
+* [Projects](projects.md)
 
 
 ### Developer? Contracting, freelance or permanent?

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ edit directly from within the Github website if you want).
 
 * [Companies](companies.md)
 * [Recruiters](recruiters.md)
+* [Groups](groups.md)
 
 
 ### Developer? Contracting, freelance or permanent?


### PR DESCRIPTION
Being social, meeting up with like-minded PHP developers and join to create more open-source projects locally is very important for a growing and vibrant eco-system. I am proposing to add a new list "Groups" that would list non-commercial groups, activities and projects such as:

 - other PHP groups / meet-ups (may have different format or structures)
 - local open-source projects (meet as a team to work on it and have fun)
 - learning PHP (teaching kids, bootcamps, etc)

Those community is what PHP lacks compared to Python or Ruby and something we (as a community) desperately need.
